### PR TITLE
feat: add standalone budget tracker page

### DIFF
--- a/public/budget-tracker.html
+++ b/public/budget-tracker.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Budget Tracker</title>
+<style>
+/* ===== Variables & Base ===== */
+:root {
+  --bg: #ffffff;
+  --panel-bg: #f7f7f7;
+  --border: #e5e7eb;
+  --text: #374151;
+  --muted: #6b7280;
+  --green: #16a34a;
+  --red: #dc2626;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Inter", sans-serif;
+  background: #f3f4f6;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 16px;
+}
+.card {
+  background: var(--bg);
+  max-width: 720px;
+  width: 100%;
+  max-height: 100vh;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+}
+header {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  padding-bottom: 8px;
+}
+h1 { margin: 0; font-size: 1.5rem; }
+.subtitle { color: var(--muted); margin-top: 4px; font-size: 0.9rem; }
+section { display: flex; flex-direction: column; gap: 8px; }
+label { font-size: 0.9rem; }
+input[type="number"], input[type="text"] {
+  width: 100%;
+  padding: 8px 12px;
+  height: 40px;
+  font-size: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+input:focus, button:focus { outline: 2px solid #3b82f6; outline-offset: 2px; }
+.expenses .row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+.expenses .cat { flex: 1; }
+.expenses .amt { width: 100px; }
+.expenses .remove {
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  line-height: 1;
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  color: var(--muted);
+  cursor: pointer;
+}
+.expenses .remove:hover { background: var(--panel-bg); }
+.btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #e5e7eb;
+  color: var(--text);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.btn:hover { background: #d1d5db; }
+.totals { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr)); gap: 8px; }
+.totals .box {
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-bg);
+}
+.totals .label { font-size: 0.8rem; color: var(--muted); }
+.totals .value { font-size: 1.2rem; font-weight: 600; }
+.summary {
+  padding: 8px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.summary.green { background: #d1fae5; color: #065f46; }
+.summary.red { background: #fee2e2; color: #991b1b; }
+.summary.neutral { background: #e5e7eb; color: var(--text); }
+.actions {
+  position: sticky;
+  bottom: 0;
+  background: var(--bg);
+  padding-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: space-between;
+  align-items: center;
+}
+.actions .right { display: flex; align-items: center; gap: 4px; font-size: 0.9rem; }
+.helper { color: var(--red); font-size: 0.75rem; }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+@media (max-width: 600px) {
+  .card { padding: 16px; }
+  .expenses .row { flex-direction: column; }
+  .expenses .amt { width: 100%; }
+  .actions { flex-direction: column; align-items: stretch; }
+  .actions .right { justify-content: flex-start; }
+}
+</style>
+</head>
+<body>
+<main class="card">
+  <header>
+    <h1>Budget Tracker</h1>
+    <p class="subtitle">Track your income, expenses, and savings in seconds.</p>
+  </header>
+
+  <section class="income">
+    <label for="income">Total Income / Allowance</label>
+    <input type="number" id="income" placeholder="e.g., 500" min="0" step="0.01" aria-describedby="income-help" />
+    <div class="helper" id="income-help"></div>
+  </section>
+
+  <section class="expenses">
+    <h2>Expenses</h2>
+    <div id="expense-rows"></div>
+    <button class="btn" id="add-expense">+ Add Expense</button>
+  </section>
+
+  <section class="totals">
+    <div class="box" data-type="total">
+      <div class="label">Total Expenses</div>
+      <div class="value" id="total-expenses">0.00</div>
+    </div>
+    <div class="box" data-type="remaining" id="remaining-box">
+      <div class="label">Remaining</div>
+      <div class="value" id="remaining">0.00</div>
+    </div>
+    <div class="box" data-type="savings">
+      <div class="label">Savings %</div>
+      <div class="value" id="savings">0%</div>
+    </div>
+  </section>
+
+  <div class="summary neutral" id="summary" aria-live="polite"></div>
+
+  <div class="actions">
+    <button class="btn" id="reset">Reset</button>
+    <label class="right"><input type="checkbox" id="save" />Remember my numbers on this device</label>
+  </div>
+</main>
+
+<script>
+const state = { income: '', expenses: [], save: false, nextId: 0 };
+(() => {
+  const storageKey = 'budgetTracker:v1';
+  const incomeEl = document.getElementById('income');
+  const incomeHelp = document.getElementById('income-help');
+  const rowsEl = document.getElementById('expense-rows');
+  const addBtn = document.getElementById('add-expense');
+  const totalEl = document.getElementById('total-expenses');
+  const remainingEl = document.getElementById('remaining');
+  const savingsEl = document.getElementById('savings');
+  const remainingBox = document.getElementById('remaining-box');
+  const summaryEl = document.getElementById('summary');
+  const resetBtn = document.getElementById('reset');
+  const saveToggle = document.getElementById('save');
+  let saveTimer;
+
+  // ===== Helpers =====
+  function parseAmount(val) {
+    const num = parseFloat(val);
+    return isFinite(num) && num > 0 ? num : 0;
+  }
+  function scheduleSave() {
+    if (!state.save) return;
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(saveState, 300);
+  }
+
+  // ===== Income =====
+  incomeEl.addEventListener('input', recalc);
+
+  // ===== Expenses =====
+  function addRow(cat = '', amount = '') {
+    const id = state.nextId++;
+    const row = { id, category: cat, amount };
+    state.expenses.push(row);
+
+    const div = document.createElement('div');
+    div.className = 'row';
+    div.id = 'row-' + id;
+    div.innerHTML = `
+      <label class="sr-only" for="cat-${id}">Category</label>
+      <input class="cat" type="text" id="cat-${id}" placeholder="Category (e.g., Food)" value="${cat}">
+      <label class="sr-only" for="amt-${id}">Amount</label>
+      <input class="amt" type="number" id="amt-${id}" placeholder="0.00" min="0" step="0.01" value="${amount}" aria-describedby="help-${id}">
+      <button class="remove" aria-label="Remove this expense" data-id="${id}">×</button>
+      <div class="helper" id="help-${id}"></div>
+    `;
+    rowsEl.appendChild(div);
+
+    document.getElementById('amt-' + id).addEventListener('input', recalc);
+    document.getElementById('cat-' + id).addEventListener('input', () => {
+      row.category = document.getElementById('cat-' + id).value;
+      scheduleSave();
+    });
+    div.querySelector('.remove').addEventListener('click', () => {
+      removeRow(id);
+    });
+  }
+  function removeRow(id) {
+    const index = state.expenses.findIndex(r => r.id === id);
+    if (index > -1) state.expenses.splice(index, 1);
+    const el = document.getElementById('row-' + id);
+    if (el) el.remove();
+    recalc();
+  }
+
+  addBtn.addEventListener('click', () => {
+    addRow();
+    recalc();
+  });
+
+  // ===== Totals & Summary =====
+  function recalc() {
+    state.income = incomeEl.value;
+    let incomeVal = parseFloat(state.income);
+    if (!isFinite(incomeVal) || incomeVal < 0) {
+      incomeHelp.textContent = incomeVal < 0 ? "Amount can't be negative" : '';
+      incomeVal = 0;
+    } else {
+      incomeHelp.textContent = '';
+    }
+
+    let total = 0;
+    state.expenses.forEach(row => {
+      const amtEl = document.getElementById('amt-' + row.id);
+      const helpEl = document.getElementById('help-' + row.id);
+      let amt = parseFloat(amtEl.value);
+      if (!isFinite(amt) || amt < 0) {
+        helpEl.textContent = amt < 0 ? "Amount can't be negative" : '';
+        amt = 0;
+      } else {
+        helpEl.textContent = '';
+      }
+      total += amt;
+      row.amount = amtEl.value;
+    });
+    const remaining = incomeVal - total;
+    const savingsPct = incomeVal > 0 ? (remaining / incomeVal) * 100 : 0;
+
+    totalEl.textContent = total.toFixed(2);
+    remainingEl.textContent = remaining.toFixed(2);
+    savingsEl.textContent = incomeVal > 0 ? savingsPct.toFixed(2) + '%' : '0%';
+
+    renderSummary(remaining);
+    colorRemaining(remaining);
+    scheduleSave();
+  }
+  function renderSummary(remaining) {
+    if (remaining > 0) {
+      summaryEl.className = 'summary green';
+      summaryEl.textContent = '✅ Great job! You’re saving money!';
+    } else if (remaining === 0) {
+      summaryEl.className = 'summary neutral';
+      summaryEl.textContent = 'ℹ️ Balanced budget. No savings this period.';
+    } else {
+      summaryEl.className = 'summary red';
+      summaryEl.textContent = '⚠️ Careful! You’re spending more than you earn.';
+    }
+  }
+  function colorRemaining(remaining) {
+    remainingBox.style.background = remaining > 0 ? '#d1fae5' : remaining < 0 ? '#fee2e2' : 'var(--panel-bg)';
+    remainingBox.style.color = remaining > 0 ? '#065f46' : remaining < 0 ? '#991b1b' : 'var(--text)';
+  }
+
+  // ===== Persistence =====
+  function saveState() {
+    const data = {
+      income: state.income,
+      expenses: state.expenses.map(r => ({
+        category: document.getElementById('cat-' + r.id).value,
+        amount: document.getElementById('amt-' + r.id).value
+      })),
+      save: state.save,
+      nextId: state.nextId
+    };
+    localStorage.setItem(storageKey, JSON.stringify(data));
+  }
+  function loadState() {
+    const data = localStorage.getItem(storageKey);
+    if (!data) return false;
+    const parsed = JSON.parse(data);
+    state.save = !!parsed.save;
+    saveToggle.checked = state.save;
+    state.nextId = parsed.nextId || 0;
+    incomeEl.value = parsed.income || '';
+    state.expenses = [];
+    rowsEl.innerHTML = '';
+    if (Array.isArray(parsed.expenses)) {
+      parsed.expenses.forEach(e => addRow(e.category, e.amount));
+    }
+    recalc();
+    return true;
+  }
+  function setDefaults() {
+    incomeEl.value = '';
+    state.expenses = [];
+    rowsEl.innerHTML = '';
+    ['Food', 'Transport', 'Entertainment', 'Misc'].forEach(c => addRow(c, ''));
+  }
+  function resetAll() {
+    setDefaults();
+    recalc();
+    localStorage.removeItem(storageKey);
+  }
+
+  saveToggle.addEventListener('change', () => {
+    state.save = saveToggle.checked;
+    if (!state.save) localStorage.removeItem(storageKey);
+    scheduleSave();
+  });
+  resetBtn.addEventListener('click', resetAll);
+
+  // ===== Init =====
+  if (!loadState()) {
+    setDefaults();
+    recalc();
+  }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add responsive single-file Budget Tracker with live calculations and local storage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found; npm install forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d9cd4ad0832095b3611bb5cab0b7